### PR TITLE
Update documentation URL to use custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,7 @@ datetimecalc/
 
 ## Documentation
 
-- [API Documentation](https://backplane.github.io/datetimecalc/) - Full API reference
-- [Development Guide](CLAUDE.md) - Contributing and architecture
+- [API Documentation](https://www.backplane.be/datetimecalc/) - Full API reference
 
 ## Contributing
 


### PR DESCRIPTION
- Change docs URL from backplane.github.io to www.backplane.be
- Remove reference to CLAUDE.md (not in source control)