### PR TITLE
Switch to uv build backend and improve package metadata

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version-file: "pyproject.toml"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -25,26 +25,12 @@ jobs:
           TAG="${GITHUB_REF##refs/tags/v}"  # e.g. 1.0.0
           grep -qE "^version = \"$TAG\"$" pyproject.toml
 
-      # https://github.com/actions/setup-python
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      # https://github.com/astral-sh/setup-uv
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
-      # # https://github.com/pypa/cibuildwheel
-      # - name: cibuildwheel
-      #   # to supply cibuildwheel options, put them in 'env', like:
-      #   # env:
-      #   #   CIBW_SOME_OPTION: value
-      #   run: |
-      #     #!/bin/sh
-      #     set -eux
-      #     pip install cibuildwheel
-      #     python -m cibuildwheel --output-dir wheelhouse
-
-      - name: pip wheel
-        run: |
-          #!/bin/sh
-          set -eux
-          pip wheel -w wheelhouse .
+      - name: Build wheel
+        run: uv build --wheel --out-dir wheelhouse
 
       # https://github.com/actions/upload-artifact
       - uses: actions/upload-artifact@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
-
 [project]
 name = "datetimecalc"
 version = "0.1.0"
@@ -10,9 +8,17 @@ license = {file = "LICENSE.txt"}
 authors = [
   {name = "Backplane", email = "actualben@users.noreply.github.com"},
 ]
+keywords = ["datetime", "timedelta", "date", "time", "calculator", "natural-language"]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "Programming Language :: Python"
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Utilities",
 ]
 dependencies = [
     "parsedatetime>=2.6",
@@ -20,15 +26,12 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/backplane/datetimecalc"
-Documentation = "https://backplane.github.io/datetimecalc/"
+Documentation = "https://www.backplane.be/datetimecalc/"
 Repository = "https://github.com/backplane/datetimecalc.git"
 Changelog = "https://github.com/backplane/datetimecalc/releases"
 
 [project.scripts]
 datetimecalc = "datetimecalc:__main__.main"
-
-[tool.setuptools.packages.find]
-where = ["src"]
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules src"
@@ -36,8 +39,8 @@ doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 pythonpath = "src/"
 
 [build-system]
-requires = ["setuptools", "setuptools-scm", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build>=0.5.0"]
+build-backend = "uv_build"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
- Replace setuptools with uv_build backend in build-system
- Update wheel.yml workflow to use uv build instead of pip wheel
- Add keywords for PyPI discoverability
- Expand classifiers (license, environment, audience, topics)
- Update Documentation URL to www.backplane.be
- Add py.typed marker for PEP 561 compliance
- Use python-version-file in docs workflow
- Remove unused setuptools-scm dependency